### PR TITLE
Fixed enumeration of pads in Panasonic EVQPUx footprints

### DIFF
--- a/Panasonic_EVQPUJ_EVQPUA.kicad_mod
+++ b/Panasonic_EVQPUJ_EVQPUA.kicad_mod
@@ -1,4 +1,4 @@
-(module Panasonic_EVQPUJ_EVQPUA (layer F.Cu) (tedit 58EB467B)
+(module Panasonic_EVQPUJ_EVQPUA (layer F.Cu) (tedit 58EB4CA2)
   (descr http://industrial.panasonic.com/cdbs/www-data/pdf/ATV0000/ATV0000CE5.pdf)
   (tags "SMD SMT SPST EVQPUJ EVQPUA")
   (attr smd)
@@ -28,9 +28,9 @@
   (fp_line (start 3.9 2.25) (end -3.9 2.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 3.9 -3.25) (end -3.9 -3.25) (layer F.CrtYd) (width 0.05))
   (pad 2 smd rect (at 2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
-  (pad 1 smd rect (at -2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at -2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/Buttons_Switches_SMD.3dshapes/Panasonic_EVQPUJ_EVQPUA.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Panasonic_EVQPUK_EVQPUB.kicad_mod
+++ b/Panasonic_EVQPUK_EVQPUB.kicad_mod
@@ -1,4 +1,4 @@
-(module Panasonic_EVQPUK_EVQPUB (layer F.Cu) (tedit 58EB44E6)
+(module Panasonic_EVQPUK_EVQPUB (layer F.Cu) (tedit 58EB4E5C)
   (descr http://industrial.panasonic.com/cdbs/www-data/pdf/ATV0000/ATV0000CE5.pdf)
   (tags "SMD SMT SPST EVQPUK EVQPUB")
   (attr smd)
@@ -28,9 +28,9 @@
   (fp_line (start 3.8 2.25) (end -3.8 2.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 3.8 -3.25) (end -3.8 -3.25) (layer F.CrtYd) (width 0.05))
   (pad 2 smd rect (at 2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
-  (pad 1 smd rect (at -2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at -2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/Buttons_Switches_SMD.3dshapes/Panasonic_EVQPUK_EVQPUB.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Panasonic_EVQPUL_EVQPUC.kicad_mod
+++ b/Panasonic_EVQPUL_EVQPUC.kicad_mod
@@ -1,4 +1,4 @@
-(module Panasonic_EVQPUL_EVQPUC (layer F.Cu) (tedit 58EB45B3)
+(module Panasonic_EVQPUL_EVQPUC (layer F.Cu) (tedit 58EB4E67)
   (descr http://industrial.panasonic.com/cdbs/www-data/pdf/ATV0000/ATV0000CE5.pdf)
   (tags "SMD SMT SPST EVQPUL EVQPUC")
   (attr smd)
@@ -28,9 +28,9 @@
   (fp_line (start 3.9 2.25) (end -3.9 2.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 3.9 -3.25) (end -3.9 -3.25) (layer F.CrtYd) (width 0.05))
   (pad 2 smd rect (at 2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
-  (pad 1 smd rect (at -2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at -2.625 0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 2.625 -0.85 180) (size 1.55 1) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at 0 1.375 180) (size 0.75 0.75) (drill 0.75) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at 0 -1.375 180) (size 0.75 0.75) (drill 0.75) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Buttons_Switches_SMD.3dshapes/Panasonic_EVQPUL_EVQPUC.wrl

--- a/Panasonic_EVQPUM_EVQPUD.kicad_mod
+++ b/Panasonic_EVQPUM_EVQPUD.kicad_mod
@@ -1,4 +1,4 @@
-(module Panasonic_EVQPUM_EVQPUD (layer F.Cu) (tedit 58EB45F3)
+(module Panasonic_EVQPUM_EVQPUD (layer F.Cu) (tedit 58EB4E72)
   (descr http://industrial.panasonic.com/cdbs/www-data/pdf/ATV0000/ATV0000CE5.pdf)
   (tags "SMD SMT SPST EVQPUM EVQPUD")
   (attr smd)
@@ -28,9 +28,9 @@
   (fp_line (start 3.8 2.25) (end -3.8 2.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 3.8 -3.25) (end -3.8 -3.25) (layer F.CrtYd) (width 0.05))
   (pad 2 smd rect (at 2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
-  (pad 1 smd rect (at -2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at -2.575 0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 2.575 -0.85 180) (size 1.45 1) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at 0 1.375 180) (size 0.75 0.75) (drill 0.75) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at 0 -1.375 180) (size 0.75 0.75) (drill 0.75) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Buttons_Switches_SMD.3dshapes/Panasonic_EVQPUM_EVQPUD.wrl


### PR DESCRIPTION
Commonized pads were swapped in the original footprints. See PR #18 for more details.

@SchrodingersGat 